### PR TITLE
v1 of metrics aggregation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.rdb
-config.y*
+*config.y*
 dist
 .DS_Store

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,11 @@ type Log struct {
 }
 
 type Metrics struct {
-	Port string `yaml:"port" default:"8080"` // default set in main.go
+	Aggregator    bool     `yaml:"aggregator" default:"false"`
+	Port          string   `yaml:"port" default:"8080"` // default set in main.go
+	Endpoints     []string `yaml:"endpoints"`
+	SleepInterval int      `yaml:"sleep_interval" default:"10"`
+	Database      Database `yaml:"database"`
 }
 
 type Database struct {
@@ -103,4 +107,12 @@ func GetHttpTransportFromContext(ctx context.Context) *http.Transport {
 		panic("GetHttpTransportFromContext failed")
 	}
 	return httpTransport
+}
+
+func GetLoadedConfigFromContext(ctx context.Context) *Config {
+	config, ok := ctx.Value(ContextKey("config")).(*Config)
+	if !ok {
+		panic("GetLoadedConfigFromContext failed")
+	}
+	return config
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -18,7 +18,7 @@ type Database struct {
 	Client       *redis.Client
 }
 
-func NewClient(ctx context.Context, config config.Database) (*redis.Client, error) {
+func NewClient(ctx context.Context, config config.Database) (*Database, error) {
 	rdb := redis.NewClient(&redis.Options{
 		Addr:     fmt.Sprintf("%s:%d", config.URL, config.Port),
 		Username: config.User,
@@ -34,13 +34,15 @@ func NewClient(ctx context.Context, config config.Database) (*redis.Client, erro
 		return nil, fmt.Errorf("unable to connect to Redis, received: %s", pong)
 	}
 
-	return rdb, nil
+	return &Database{
+		Client: rdb,
+	}, nil
 }
 
-func GetDatabaseFromContext(ctx context.Context) (Database, error) {
-	database, ok := ctx.Value(config.ContextKey("database")).(Database)
+func GetDatabaseFromContext(ctx context.Context) (*Database, error) {
+	database, ok := ctx.Value(config.ContextKey("database")).(*Database)
 	if !ok {
-		return Database{}, errors.New("GetDatabaseFromContext failed (is your database running and enabled in your config.yml?)")
+		return nil, errors.New("GetDatabaseFromContext failed (is your database running and enabled in your config.yml?)")
 	}
 	return database, nil
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -5,10 +5,8 @@ import (
 	"log/slog"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/veertuinc/anklet/internal/config"
-	"github.com/veertuinc/anklet/internal/metrics"
 )
 
 func New() *slog.Logger {
@@ -74,10 +72,6 @@ func AppendCtx(parent context.Context, attr slog.Attr) context.Context {
 func Panic(workerCtx context.Context, serviceCtx context.Context, errorMessage string) {
 	logger := GetLoggerFromContext(serviceCtx)
 	logger.ErrorContext(serviceCtx, errorMessage)
-	metrics.UpdateService(workerCtx, serviceCtx, logger, metrics.Service{
-		Status:        "failed",
-		LastFailedRun: time.Now(),
-	})
 	panic(errorMessage)
 }
 

--- a/internal/metrics/aggregator.go
+++ b/internal/metrics/aggregator.go
@@ -1,0 +1,101 @@
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/veertuinc/anklet/internal/config"
+	"github.com/veertuinc/anklet/internal/database"
+)
+
+// Start runs the HTTP server
+func (s *Server) StartAggregatorServer(workerCtx context.Context, logger *slog.Logger) {
+	http.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("format") == "json" {
+			s.handleAggregatorJsonMetrics(workerCtx, logger)(w, r)
+		} else if r.URL.Query().Get("format") == "prometheus" {
+			s.handleAggregatorPrometheusMetrics(workerCtx, logger)(w, r)
+		} else {
+			http.Error(w, "unsupported format, please use '?format=json' or '?format=prometheus'", http.StatusBadRequest)
+		}
+	})
+	http.ListenAndServe(":"+s.Port, nil)
+}
+
+func (s *Server) handleAggregatorJsonMetrics(workerCtx context.Context, logger *slog.Logger) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		databaseContainer, err := database.GetDatabaseFromContext(workerCtx)
+		if err != nil {
+			logger.ErrorContext(workerCtx, "Error getting database client from context", "error", err)
+			return
+		}
+		loadedConfig := config.GetLoadedConfigFromContext(workerCtx)
+		var combinedMetrics []map[string]MetricsData
+		for _, endpoint := range loadedConfig.Metrics.Endpoints {
+			value, err := databaseContainer.Client.Get(workerCtx, endpoint).Result()
+			if err != nil {
+				logger.ErrorContext(workerCtx, "Error getting value from Redis", "key", endpoint, "error", err)
+				return
+			}
+			var metricsData MetricsData
+			err = json.Unmarshal([]byte(value), &metricsData)
+			if err != nil {
+				logger.ErrorContext(workerCtx, "Error unmarshalling metrics data", "error", err)
+				return
+			}
+			combinedMetrics = append(combinedMetrics, map[string]MetricsData{endpoint: metricsData})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(combinedMetrics)
+	}
+}
+
+func (s *Server) handleAggregatorPrometheusMetrics(parentCtx context.Context, logger *slog.Logger) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		metricsData := GetMetricsDataFromContext(parentCtx)
+		fmt.Fprintf(w, "%+v", metricsData)
+
+	}
+}
+
+func UpdateEndpointMetrics(serviceCtx context.Context, logger *slog.Logger, endpoint string) {
+	resp, err := http.Get(endpoint + "/metrics?format=json")
+	if err != nil {
+		logger.ErrorContext(serviceCtx, "Error fetching metrics from endpoint", "endpoint", endpoint, "error", err)
+		return
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.ErrorContext(serviceCtx, "Error reading response body", "endpoint", endpoint, "error", err)
+		return
+	}
+	var metricsData MetricsData
+	err = json.Unmarshal(body, &metricsData)
+	if err != nil {
+		logger.ErrorContext(serviceCtx, "Error unmarshalling metrics data", "endpoint", endpoint, "error", err)
+		return
+	}
+	logger.InfoContext(serviceCtx, "obtained metrics from endpoint", "metrics", metricsData)
+	databaseContainer, err := database.GetDatabaseFromContext(serviceCtx)
+	if err != nil {
+		logger.ErrorContext(serviceCtx, "Error getting database client from context", "error", err)
+		return
+	}
+	// Store the JSON data in Redis
+	setting := databaseContainer.Client.Set(serviceCtx, endpoint, body, 0)
+	if setting.Err() != nil {
+		logger.ErrorContext(serviceCtx, "Error storing metrics data in Redis", "error", setting.Err())
+		return
+	}
+	exists, err := databaseContainer.Client.Exists(serviceCtx, endpoint).Result()
+	if err != nil {
+		logger.ErrorContext(serviceCtx, "Error checking if key exists in Redis", "key", endpoint, "error", err)
+		return
+	}
+	logger.InfoContext(serviceCtx, "Successfully stored metrics data in Redis", "key", endpoint, "exists", exists)
+}


### PR DESCRIPTION
Per https://github.com/veertuinc/anklet/issues/18, we're creating a way for metrics from a list of endpoints to be combined.

The aggregator service runs as part of the main anklet package. Users will configure Anklet without any services (example to be added to README). It will expose a port and then queries can be made for :[port]/metrics?format=json as they would for the normal metrics endpoint, but get back an array like
```
[
  "{url for endpoint}": { metrics from that endpoint},
 . . .
```